### PR TITLE
Move api.asyncy.com from a redirect to the actual ingress so that a C…

### DIFF
--- a/kubernetes/ingress/graphql.yaml
+++ b/kubernetes/ingress/graphql.yaml
@@ -15,9 +15,25 @@ spec:
   tls:
   - hosts:
     - api.storyscript.io
+    - api.asyncy.com
     secretName: storyscript.io
   rules:
   - host: api.storyscript.io
+    http:
+      paths:
+      - path: /graphql
+        backend:
+          serviceName: graphql
+          servicePort: 5000
+      - path: /graphiql
+        backend:
+          serviceName: graphql
+          servicePort: 5000
+      - path: /_postgraphile
+        backend:
+          serviceName: graphql
+          servicePort: 5000
+  - host: api.asyncy.com
     http:
       paths:
       - path: /graphql

--- a/kubernetes/ingress/nginx-proxy-web-and-blog.yaml
+++ b/kubernetes/ingress/nginx-proxy-web-and-blog.yaml
@@ -18,7 +18,6 @@ spec:
     - docs.asyncy.com
     - hub.asyncy.com
     - api.hub.asyncy.com
-    - api.asyncy.com
     secretName: storyscript.io
   rules:
   - host: asyncy.com
@@ -36,13 +35,6 @@ spec:
           serviceName: nginx-proxy-web-and-blog
           servicePort: 8089
   - host: hub.asyncy.com
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: nginx-proxy-web-and-blog
-          servicePort: 8089
-  - host: api.asyncy.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
…NAME record to api.asyncy.com works out of the box - helps with all old CLI clients.