### PR TITLE
Remove need for GOPATH

### DIFF
--- a/skaffold-deploy.yaml
+++ b/skaffold-deploy.yaml
@@ -39,7 +39,7 @@ build:
     docker:
       dockerfile: Dockerfile
   - image: asyncy/openapiwatcher
-    context: ../GOPATH/src/github.com/storyscript/openapiwatcher/
+    context: ../openapiwatcher/
     docker:
       dockerfile: Dockerfile
   local: {}


### PR DESCRIPTION
We previously thought we would need the GOPATH for building, but it
should happen inside the docker container so this is a simplification.